### PR TITLE
build: add node.js module support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ libold/
 *.cl.h
 *.h.h
 scripts/libccurl.so
+.DS_Store
+node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,0 +1,12 @@
+var path = require('path');
+
+var ffi = require('ffi');
+
+var ccurl = path.join(__dirname, 'build', 'lib', 'libccurl')
+var libccurl = ffi.Library(ccurl, {
+    ccurl_pow : [ 'string', [ 'string', 'int'] ],
+    ccurl_pow_finalize : [ 'void', [] ],
+    ccurl_pow_interrupt: [ 'void', [] ]
+});
+
+module.exports = libccurl

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ccurl",
+  "version": "0.2.0",
+  "description": "C port of the Curl library",
+  "main": "index.js",
+  "scripts": {
+    "install": "npm run compile",
+    "compile": "cmake-js compile"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iotaledger/ccurl.git"
+  },
+  "author": "IOTA AS, IOTA Foundation & Developers (https://iotatoken.com)",
+  "license": "MIT",
+  "dependencies": {
+    "cmake-js": "^3.5.0",
+    "ffi": "^2.2.0"
+  },
+  "keywords": [
+    "iota"
+  ]
+}


### PR DESCRIPTION
This patch enables Node.js module authors to define `ccurl` as
one of their dependencies in their `package.json`. It's then
build for the current platform and Node version on installation
time of the module.

Main functions of ccurl are exposed in `index.js`.

Usage:

```
npm install ccurl # given you published the module to npm

const ccurl = require('ccurl')
ccurl.ccurl_pow(/* ... */)

```

**Notes:**

I'm happy about feedback. I believe this would make development for iotaledger/wallet and other Node.js based projects easier.

Another option is to use a separate repository (in or outside the ioto org)

However in this place we have already travis hooks etc that could be used for automatic publishes to the registry when the C code changes. It also made things easier with path management for the build-result.

**Remaining tasks:**

- [ ] publish to npm
