### PR TITLE
remove inline for loop variable declaration

### DIFF
--- a/src/cli/trytes-to-trits.c
+++ b/src/cli/trytes-to-trits.c
@@ -48,7 +48,8 @@ int main(int argc, char* argv[]) {
   init_converter();
   size_t length = strlen(buf);
   char* input = trits_from_trytes(buf, length);
-  for(int i = 0; i < length * 3; i++ ) {
+  int i = 0;
+  for(i = 0; i < length * 3; i++ ) {
 	  switch(input[i]) {
 		  case 1: {
 					  fprintf(stdout, "+");

--- a/src/lib/claccess/clcontext.c
+++ b/src/lib/claccess/clcontext.c
@@ -30,7 +30,8 @@ int check_clerror(cl_int err, char *comment, ...) {
 */
 
 void free_platforms(cl_platform_id* platforms, cl_uint num_platforms) {
-  for (cl_uint i = 0; i < num_platforms; i++) {
+  cl_uint i = 0;
+  for (i = 0; i < num_platforms; i++) {
     clUnloadPlatformCompiler(platforms[i]);
   }
   free(platforms);


### PR DESCRIPTION
Removed inline loop variable declaration to achieve compatibility with compilers older than C99