### PR TITLE
Trits signed char (ARM Compatibility Change)

### DIFF
--- a/src/cli/trytes-to-long.c
+++ b/src/cli/trytes-to-long.c
@@ -46,8 +46,8 @@ int main(int argc, char* argv[]) {
     }
   }
   size_t length = strlen(buf);
-  char* input = trits_from_trytes(buf, length);
-  char value = long_value(input, 0, length * 3);
+  signed char* input = trits_from_trytes(buf, length);
+  signed char value = long_value(input, 0, length * 3);
   fprintf(stdout, "%hhd", value);
   return 0;
 }

--- a/src/cli/trytes-to-trits.c
+++ b/src/cli/trytes-to-trits.c
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
     }
   }
   size_t length = strlen(buf);
-  char* input = trits_from_trytes(buf, length);
+  signed char* input = trits_from_trytes(buf, length);
   int i = 0;
   for(i = 0; i < length * 3; i++ ) {
 	  switch(input[i]) {

--- a/src/lib/curl.c
+++ b/src/lib/curl.c
@@ -72,7 +72,7 @@ void init_curl(curl_t* ctx) {
   memset(ctx->state, 0, STATE_LENGTH * sizeof(char));
 }
 int i = 0;
-void absorb(curl_t* ctx, char* const trits, int length) {
+void absorb(curl_t* ctx, signed char* const trits, int length) {
   int offset = 0;
   do {
     memcpy(ctx->state, trits + offset,
@@ -82,11 +82,9 @@ void absorb(curl_t* ctx, char* const trits, int length) {
   } while ((length -= HASH_LENGTH) > 0);
 }
 
-void squeeze(curl_t* ctx, char* trits, int length) {
+void squeeze(curl_t* ctx, signed char* trits, int length) {
   int offset = 0;
   do {
-    // memcpy(trits+offset,  ctx->state, (length < HASH_LENGTH? length:
-    // HASH_LENGTH) * sizeof(char));
     memcpy(&(trits[offset]), ctx->state,
            (length < HASH_LENGTH ? length : HASH_LENGTH) * sizeof(char));
     transform(ctx);
@@ -96,11 +94,11 @@ void squeeze(curl_t* ctx, char* trits, int length) {
 
 void transform(curl_t* ctx) {
   int round, stateIndex;
-  char scratchpad[STATE_LENGTH];
+  signed char scratchpad[STATE_LENGTH];
   for (round = 0; round < NUMBER_OF_ROUNDS; round++) {
     memcpy(scratchpad, ctx->state, STATE_LENGTH * sizeof(char));
     for (stateIndex = 0; stateIndex < STATE_LENGTH; stateIndex++) {
-      ctx->state[stateIndex] = TRUTH_TABLE[scratchpad[INDEX[stateIndex]] +
+        ctx->state[stateIndex] = TRUTH_TABLE[scratchpad[INDEX[stateIndex]] +
                                            (scratchpad[INDEX[stateIndex+1]]<<2) +5 ];
     }
   }

--- a/src/lib/curl.h
+++ b/src/lib/curl.h
@@ -7,12 +7,12 @@
 #include <time.h>
 
 
-typedef struct { char state[STATE_LENGTH]; } curl_t;
+typedef struct { signed char state[STATE_LENGTH]; } curl_t;
 
 EXPORT void init_curl(curl_t* ctx);
 
-EXPORT void absorb(curl_t* ctx, char* const trits, int length);
-EXPORT void squeeze(curl_t* ctx, char* const trits, int length);
+EXPORT void absorb(curl_t* ctx, signed char* const trits, int length);
+EXPORT void squeeze(curl_t* ctx, signed char* const trits, int length);
 EXPORT void reset(curl_t* ctx);
 
 #endif

--- a/src/lib/exports.c
+++ b/src/lib/exports.c
@@ -8,8 +8,8 @@ EXPORT char* ccurl_digest_transaction(char* trytes) {
   curl_t curl;
   init_curl(&curl);
   size_t length = strnlen(trytes, TRANSACTION_LENGTH);
-  char digest[HASH_LENGTH];
-  char* input =
+  signed char digest[HASH_LENGTH];
+  signed char* input =
       trits_from_trytes(trytes, length < TRYTE_LENGTH ? length : TRYTE_LENGTH);
   absorb(&curl, input, length * 3);
   squeeze(&curl, digest, HASH_LENGTH);

--- a/src/lib/exports_cl.c
+++ b/src/lib/exports_cl.c
@@ -69,7 +69,7 @@ EXPORT void ccurl_pow_interrupt() {
 EXPORT char* ccurl_pow(char* trytes, int minWeightMagnitude) {
   char* buf = NULL; //= malloc(sizeof(char)*TRYTE_LENGTH);
   size_t len = strnlen(trytes, TRANSACTION_LENGTH/3);
-  char* trits = trits_from_trytes(trytes, len);
+  signed char* trits = trits_from_trytes(trytes, len);
   pdcl_node_t* pd_node = &base;
 
   ccurl_pow_node_init(pd_node);

--- a/src/lib/hash.h
+++ b/src/lib/hash.h
@@ -19,7 +19,7 @@
 #define TRYTE_LENGTH 2673
 #define TRANSACTION_LENGTH TRYTE_LENGTH * 3
 typedef int64_t bc_trit_t;
-typedef char trit_t;
+typedef signed char trit_t;
 
 #ifndef DEBUG
 #define DEBUG

--- a/src/lib/pearl_diver.c
+++ b/src/lib/pearl_diver.c
@@ -19,7 +19,7 @@
 
 typedef struct {
   States* states;
-  char* trits;
+  signed char* trits;
   int min_weight_magnitude;
   int threadIndex;
   PearlDiver* ctx;
@@ -191,7 +191,7 @@ void* find_nonce(void* data) {
   int i, shift;
   bc_trit_t nonce_probe, nonce_output;
   PDThread* my_thread = (PDThread*)data;
-  char* trits = my_thread->trits;
+  signed char* trits = my_thread->trits;
 
   memset(midStateCopyLow, 0, STATE_LENGTH * sizeof(bc_trit_t));
   memset(midStateCopyHigh, 0, STATE_LENGTH * sizeof(bc_trit_t));

--- a/src/lib/util/converter.c
+++ b/src/lib/util/converter.c
@@ -35,7 +35,7 @@ char TRYTE_TO_TRITS_MAPPINGS
 
 static const char* TRYTE_ALPHABET = TRYTE_STRING;
 
-char long_value(char* const trits, const int offset, const int size) {
+char long_value(signed char* const trits, const int offset, const int size) {
   int i;
 
   char value = 0;
@@ -45,7 +45,7 @@ char long_value(char* const trits, const int offset, const int size) {
   return value;
 }
 
-char* bytes_from_trits(char* const trits, const int offset, const int size) {
+char* bytes_from_trits(signed char* const trits, const int offset, const int size) {
   int i, j;
   int length =
       (size + NUMBER_OF_TRITS_IN_A_BYTE - 1) / NUMBER_OF_TRITS_IN_A_BYTE;
@@ -65,7 +65,7 @@ char* bytes_from_trits(char* const trits, const int offset, const int size) {
   return bytes;
 }
 
-void getTrits(const char* bytes, int bytelength, char* const trits,
+void getTrits(const char* bytes, int bytelength, signed char* const trits,
               int length) {
   int i;
 
@@ -88,9 +88,9 @@ void getTrits(const char* bytes, int bytelength, char* const trits,
   }
 }
 
-char* trits_from_trytes(const char* trytes, int length) {
+signed char* trits_from_trytes(const char* trytes, int length) {
   int i;
-  char* trits = malloc(length * NUMBER_OF_TRITS_IN_A_TRYTE * sizeof(char));
+  signed char* trits = malloc(length * NUMBER_OF_TRITS_IN_A_TRYTE * sizeof(char));
   for (i = 0; i < length; i++) {
     memcpy(trits + i * NUMBER_OF_TRITS_IN_A_TRYTE,
            TRYTE_TO_TRITS_MAPPINGS[strchr(TRYTE_ALPHABET, trytes[i]) -
@@ -101,11 +101,11 @@ char* trits_from_trytes(const char* trytes, int length) {
   return trits;
 }
 
-void copyTrits(char const value, char* const destination, const int offset,
+void copyTrits(signed char const value, signed char* const destination, const int offset,
                const int size) {
   int i;
 
-  char absoluteValue = value < 0 ? -value : value;
+  signed char absoluteValue = value < 0 ? -value : value;
   for (i = 0; i < size; i++) {
 
     int remainder = (int)(absoluteValue % RADIX);
@@ -125,7 +125,7 @@ void copyTrits(char const value, char* const destination, const int offset,
   }
 }
 
-char* trytes_from_trits(char* const trits, const int offset, const int size) {
+char* trytes_from_trits(signed char* const trits, const int offset, const int size) {
   int i;
   const int length =
       (size + NUMBER_OF_TRITS_IN_A_TRYTE - 1) / NUMBER_OF_TRITS_IN_A_TRYTE;
@@ -133,7 +133,7 @@ char* trytes_from_trits(char* const trits, const int offset, const int size) {
   trytes[length] = '\0';
 
   for (i = 0; i < length; i++) {
-    char j = trits[offset + i * 3] + trits[offset + i * 3 + 1] * 3 +
+    signed char j = trits[offset + i * 3] + trits[offset + i * 3 + 1] * 3 +
                trits[offset + i * 3 + 2] * 9;
     if (j < 0) {
       j += 27;
@@ -143,11 +143,11 @@ char* trytes_from_trits(char* const trits, const int offset, const int size) {
   return trytes;
 }
 
-char tryteValue(char* const trits, const int offset) {
+char tryteValue(signed char* const trits, const int offset) {
   return trits[offset] + trits[offset + 1] * 3 + trits[offset + 2] * 9;
 }
 
-static void increment(char* trits, int size) {
+static void increment(signed char* trits, int size) {
   int i;
   for (i = 0; i < size; i++) {
     if (++trits[i] > MAX_TRIT_VALUE) {
@@ -161,7 +161,7 @@ static void increment(char* trits, int size) {
 void init_converter (void) __attribute__ ((constructor));
 void init_converter() {
   int i;
-  char trits[NUMBER_OF_TRITS_IN_A_BYTE];
+  signed char trits[NUMBER_OF_TRITS_IN_A_BYTE];
   memset(trits, 0, NUMBER_OF_TRITS_IN_A_BYTE * sizeof(char));
   for (i = 0; i < HASH_LENGTH; i++) {
     memcpy(&(BYTE_TO_TRITS_MAPPINGS[i]), trits,

--- a/src/lib/util/converter.h
+++ b/src/lib/util/converter.h
@@ -3,16 +3,16 @@
 
 #include "../hash.h"
 
-char long_value(char* const trits, const int offset, const int size);
-char charValue(char* const trits, const int offset, const int size);
-char* bytes_from_trits(char* const trits, const int offset, const int size);
-void getTrits(const char* bytes, int bytelength, char* const trits,
+char long_value(signed char* const trits, const int offset, const int size);
+char charValue(signed char* const trits, const int offset, const int size);
+char* bytes_from_trits(signed char* const trits, const int offset, const int size);
+void getTrits(const char* bytes, int bytelength, signed char* const trits,
               int length);
 int indexOf(char* values, char find);
-char* trits_from_trytes(const char* trytes, int length);
-void copyTrits(char const value, char* const destination, const int offset,
+signed char* trits_from_trytes(const char* trytes, int length);
+void copyTrits(signed char const value, signed char* const destination, const int offset,
                const int size);
-char* trytes_from_trits(char* const trits, const int offset, const int size);
-char tryteValue(char* const trits, const int offset);
+char* trytes_from_trits(signed char* const trits, const int offset, const int size);
+char tryteValue(signed char* const trits, const int offset);
 
 #endif


### PR DESCRIPTION
Fix to issue #39.

Before this PR, the code does not compile correctly on ARM due to a difference in CHAR implementation between x86 and ARM. x86 implementation treat CHAR as SIGNED CHAR, whereas ARM treats CHAR as UNSIGNED CHAR. Note that there isn't a standard for C how CHARs are signed or unsigned.

This difference in C spec results in unexpected results on ARM. The code multiplies by Trite which on x86 is [-1, 0 or 1] and on ARM [255, 0 or 1] which results in copying data from incorrect memory locations.

To make the code portable it is essential that all Trits are defined as SIGNED CHAR. Secondly Trytes on the other hand should be UNSIGNED CHARS "ABCDEF..XYZ9". There is no math done with Trytes so this is no as big of an issue as Trits.